### PR TITLE
F/plugin creator fix

### DIFF
--- a/dev-utils/plugin_skeleton_creator/create_plugin.sh
+++ b/dev-utils/plugin_skeleton_creator/create_plugin.sh
@@ -25,7 +25,7 @@ file_list="plugin_template_grammar.ym
            plugin_template_parser.h
            plugin_template_plugin.c"
 
-while getopts "k:n:t:h" opt; do
+while getopts "k:n:t:d:h" opt; do
   case ${opt} in
     h)
       help=1

--- a/dev-utils/plugin_skeleton_creator/create_plugin.sh
+++ b/dev-utils/plugin_skeleton_creator/create_plugin.sh
@@ -3,7 +3,7 @@
 top_srcdir="$(git rev-parse --show-toplevel)"
 
 function print_help {
-  echo "This script help to create new plugin with creating skeleton"
+  echo "This script helps to create new plugin by creating a skeleton"
   echo "Parameters:"
   echo -e "\t-n\tName of the plugin (required)"
   echo -e "\t-k\tThe keyword in config file (default: name of the plugin)"


### PR DESCRIPTION
It was not possible to set the root directory of the skeleton due to the missing "d" option. If the root directory was set the script printed the following and created the skeleton in the default directory.

```
$ ./create_plugin.sh -n dummy -d ~/syslog-ng-incubator/  
./create_plugin.sh: illegal option -- d   
plugin name = dummy
plugin type = LL_CONTEXT_DESTINATION  
plugin key = dummy  
Done: new plugin skeleton is created in ~/syslog-ng/modules/dummy
```

In order to fix the problem, the root directory is added to the options.

In addition, minor grammar mistakes are fixed in the help text.
